### PR TITLE
Detect terminal width and limit separators accordingly

### DIFF
--- a/src/main/java/de/holube/request_sink/io/GroupBuilder.java
+++ b/src/main/java/de/holube/request_sink/io/GroupBuilder.java
@@ -10,14 +10,14 @@ import java.util.List;
  * into a structured output.
  * <p>
  * This class collects multiple {@link LineBuilder} instances and calculates the maximum
- * lengths of keys and values to ensure proper alignment when building the final output.
+ * widths of keys and values to ensure proper alignment when building the final output.
  */
 public final class GroupBuilder {
 
     private final List<LineBuilder> lineBuilders = new ArrayList<>();
 
-    private int maxKeyLength = 0;
-    private int maxValueLength = 0;
+    private int maxKeyWidth = 0;
+    private int maxValueWidth = 0;
 
     /**
      * Adds a {@link LineBuilder} to the group.
@@ -28,24 +28,24 @@ public final class GroupBuilder {
         lineBuilders.add(lineBuilder);
 
         final int keyLength = lineBuilder.key().length();
-        if (maxKeyLength < keyLength)
-            maxKeyLength = keyLength;
+        if (maxKeyWidth < keyLength)
+            maxKeyWidth = keyLength;
 
         final int valueLength = lineBuilder.value().length();
-        if (maxValueLength < valueLength)
-            maxValueLength = valueLength;
+        if (maxValueWidth < valueLength)
+            maxValueWidth = valueLength;
     }
 
     /**
-     * Returns the maximum length of lines in the group.
-     * This is calculated as the sum of the maximum key length,
-     * the length of the colon and space (2 characters),
-     * and the maximum value length.
+     * Returns the maximum width of lines in the group.
+     * This is calculated as the sum of the maximum key width,
+     * the width of the colon and space (2 characters),
+     * and the maximum value width.
      *
-     * @return the maximum length of lines
+     * @return the maximum width of lines
      */
-    int getLength() {
-        return maxKeyLength + 2 + maxValueLength;
+    int getWidth() {
+        return maxKeyWidth + 2 + maxValueWidth;
     }
 
     /**
@@ -54,7 +54,7 @@ public final class GroupBuilder {
      * @param sb the {@link StringBuilder} to append the formatted output to
      */
     public void build(@NonNull StringBuilder sb) {
-        lineBuilders.forEach(lb -> lb.build(sb, maxKeyLength));
+        lineBuilders.forEach(lb -> lb.build(sb, maxKeyWidth));
     }
 
 }

--- a/src/main/java/de/holube/request_sink/io/LineBuilder.java
+++ b/src/main/java/de/holube/request_sink/io/LineBuilder.java
@@ -25,7 +25,7 @@ public record LineBuilder(
      * The key is followed by a colon and a space, then padded with spaces
      * to match the specified key width, and finally the value is appended.
      * <p>
-     * The key width must be greater than or equal to the length of the key.
+     * The key width must be greater than or equal to the width of the key.
      *
      * @param sb       the StringBuilder to append the formatted line to
      * @param keyWidth the width to which the key should be padded

--- a/src/main/java/de/holube/request_sink/io/OutputBuilder.java
+++ b/src/main/java/de/holube/request_sink/io/OutputBuilder.java
@@ -25,45 +25,45 @@ public final class OutputBuilder {
     }
 
     public String build() {
-        final int length = getLength();
+        final int maxWidth = getWidth();
 
         final StringBuilder sb = new StringBuilder();
 
-        buildSeparator(sb, "Request " + id + " Start", "=", length);
+        buildSeparator(sb, "Request " + id + " Start", "=", maxWidth);
         metadata.build(sb);
-        buildSeparator(sb, "Headers Start", "-", length);
+        buildSeparator(sb, "Headers Start", "-", maxWidth);
         headers.build(sb);
-        buildSeparator(sb, "Headers End", "-", length);
+        buildSeparator(sb, "Headers End", "-", maxWidth);
         if (body.isEmpty())
-            buildSeparator(sb, "No body in request", "-", length);
+            buildSeparator(sb, "No body in request", "-", maxWidth);
         else {
-            buildSeparator(sb, "Body Start", "-", length);
+            buildSeparator(sb, "Body Start", "-", maxWidth);
             sb.append(body).append("\n");
-            buildSeparator(sb, "Body End", "-", length);
+            buildSeparator(sb, "Body End", "-", maxWidth);
         }
-        buildSeparator(sb, "Request " + id + " End", "=", length);
+        buildSeparator(sb, "Request " + id + " End", "=", maxWidth);
 
         return sb.toString();
     }
 
-    private int getLength() {
-        final int metadataLength = metadata.getLength();
-        final int headersLength = headers.getLength();
-        final int minLength = String.valueOf(id).length() + 20;
-        final int maxLength = Math.max(Math.max(metadataLength, headersLength), minLength);
+    private int getWidth() {
+        final int metadataLength = metadata.getWidth();
+        final int headersLength = headers.getWidth();
+        final int minWidth = String.valueOf(id).length() + 20;
+        final int maxWidth = Math.max(Math.max(metadataLength, headersLength), minWidth);
         CommandLine.Model.UsageMessageSpec usageMessageSpec = new CommandLine.Model.UsageMessageSpec();
         usageMessageSpec.autoWidth(true);
         final int terminalWidth = usageMessageSpec.width();
-        return Math.min(maxLength, terminalWidth);
+        return Math.min(maxWidth, terminalWidth);
     }
 
-    private void buildSeparator(StringBuilder sb, String message, String sides, int length) {
-        int sideLengths = (length - message.length() - 2) / 2;
+    private void buildSeparator(StringBuilder sb, String message, String sides, int maxWidth) {
+        int sideWidths = (maxWidth - message.length() - 2) / 2;
 
-        sb.append(sides.repeat(sideLengths))
+        sb.append(sides.repeat(sideWidths))
                 .append(" ").append(message).append(" ")
-                .append(sides.repeat(sideLengths));
-        if (sideLengths * 2 + 2 + message.length() < length)
+                .append(sides.repeat(sideWidths));
+        if (sideWidths * 2 + 2 + message.length() < maxWidth)
             sb.append(sides);
         sb.append("\n");
     }

--- a/src/test/java/de/holube/request_sink/io/GroupBuilderTest.java
+++ b/src/test/java/de/holube/request_sink/io/GroupBuilderTest.java
@@ -16,7 +16,7 @@ class GroupBuilderTest {
         groupBuilder.addLine(lineBuilder1);
         groupBuilder.addLine(lineBuilder2);
 
-        assertEquals("key2: value2".length(), groupBuilder.getLength());
+        assertEquals("key2: value2".length(), groupBuilder.getWidth());
     }
 
     @Test
@@ -46,23 +46,23 @@ class GroupBuilderTest {
     }
 
     @Test
-    void testGetLengthWithNoLines() {
+    void testGetWidthWithNoLines() {
         GroupBuilder groupBuilder = new GroupBuilder();
-        assertEquals(2, groupBuilder.getLength());
+        assertEquals(2, groupBuilder.getWidth());
     }
 
     @Test
-    void testGetLengthWithSingleLine() {
+    void testGetWidthWithSingleLine() {
         GroupBuilder groupBuilder = new GroupBuilder();
         LineBuilder lineBuilder = new LineBuilder("singleKey", "singleValue");
 
         groupBuilder.addLine(lineBuilder);
 
-        assertEquals("singleKey: singleValue".length(), groupBuilder.getLength());
+        assertEquals("singleKey: singleValue".length(), groupBuilder.getWidth());
     }
 
     @Test
-    void testGetLengthWithMultipleLines() {
+    void testGetWidthWithMultipleLines() {
         GroupBuilder groupBuilder = new GroupBuilder();
         LineBuilder lineBuilder1 = new LineBuilder("short", "value");
         LineBuilder lineBuilder2 = new LineBuilder("longerKey", "anotherValue");
@@ -70,17 +70,17 @@ class GroupBuilderTest {
         groupBuilder.addLine(lineBuilder1);
         groupBuilder.addLine(lineBuilder2);
 
-        assertEquals("longerKey: anotherValue".length(), groupBuilder.getLength());
+        assertEquals("longerKey: anotherValue".length(), groupBuilder.getWidth());
     }
 
     @Test
-    void testGetLengthWithEmptyLine() {
+    void testGetWidthWithEmptyLine() {
         GroupBuilder groupBuilder = new GroupBuilder();
         LineBuilder lineBuilder1 = new LineBuilder("", "");
 
         groupBuilder.addLine(lineBuilder1);
 
-        assertEquals(2, groupBuilder.getLength());
+        assertEquals(2, groupBuilder.getWidth());
     }
 
 }

--- a/src/test/java/de/holube/request_sink/io/OutputBuilderTest.java
+++ b/src/test/java/de/holube/request_sink/io/OutputBuilderTest.java
@@ -156,7 +156,7 @@ class OutputBuilderTest {
     void testWithMaxWidth() {
         OutputBuilder outputBuilder = new OutputBuilder();
         outputBuilder.setId(42);
-        outputBuilder.addMetadataLine("URL", "/api/patch?id=78934532946509236592346752347986792348769074259345602906592396");
+        outputBuilder.addMetadataLine("URL", "/api/patch?id=78934532946509236592456456346752347986792348769074259345602906592396");
         outputBuilder.addHeaderLine("Content-Type", "application/json");
         outputBuilder.addHeaderLine("User-Agent", "TestAgent/3.0");
         outputBuilder.setBody("{\"key\":\"value\"}");
@@ -165,8 +165,8 @@ class OutputBuilderTest {
 
         // Default width by picocli is 80 characters.
         String expectedOutput = """
-                =============================== Request 5 Start ================================
-                URL:    /api/patch?id=78934532946509236592346752347986792348769074259345602906592396
+                =============================== Request 42 Start ===============================
+                URL: /api/patch?id=78934532946509236592456456346752347986792348769074259345602906592396
                 -------------------------------- Headers Start ---------------------------------
                 Content-Type: application/json
                 User-Agent:   TestAgent/3.0
@@ -174,7 +174,7 @@ class OutputBuilderTest {
                 ---------------------------------- Body Start ----------------------------------
                 {"key":"value"}
                 ----------------------------------- Body End -----------------------------------
-                ================================ Request 5 End =================================
+                ================================ Request 42 End ================================
                 """;
         assertEquals(expectedOutput, actualOutput);
     }


### PR DESCRIPTION
- Detects terminal width with picocli.
- Limits separator width accordingly.
- This is currently limited to a minimum of 55 characters, since this is the minium usage width from picocli.